### PR TITLE
Improved analysis performance for large Java files.

### DIFF
--- a/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/SignatureResolverTestBase.java
+++ b/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/SignatureResolverTestBase.java
@@ -31,12 +31,15 @@ public abstract class SignatureResolverTestBase {
 
   protected IType type;
 
+  protected SignatureResolver resolver;
+
   protected void createMethodIndex() throws JavaModelException {
     methodsByName = new HashMap<String, IMethod>();
     final IMethod[] methods = type.getMethods();
     for (int i = 0; i < methods.length; i++) {
       methodsByName.put(methods[i].getElementName(), methods[i]);
     }
+    resolver = new SignatureResolver(type);
   }
 
   private IMethod getMethod(final String name) {
@@ -48,7 +51,7 @@ public abstract class SignatureResolverTestBase {
   private void assertSignature(final String methodName, final String signature)
       throws Exception {
     final IMethod method = getMethod(methodName);
-    assertEquals(signature, SignatureResolver.getParameters(method));
+    assertEquals(signature, resolver.getParameters(method));
   }
 
   @Test
@@ -153,7 +156,8 @@ public abstract class SignatureResolverTestBase {
 
   @Test
   public void test_classTypeVariableExtends() throws Exception {
-    assertSignature("method_classTypeVariableExtends", "Ljava/lang/Comparable;");
+    assertSignature("method_classTypeVariableExtends",
+        "Ljava/lang/Comparable;");
   }
 
   @Test

--- a/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/SourceSignatureResolverTest.java
+++ b/org.eclipse.eclemma.core.test/src/org/eclipse/eclemma/internal/core/analysis/SourceSignatureResolverTest.java
@@ -13,14 +13,14 @@ package org.eclipse.eclemma.internal.core.analysis;
 
 import static org.junit.Assert.assertEquals;
 
+import org.eclipse.eclemma.core.JavaProjectKit;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import org.eclipse.eclemma.core.JavaProjectKit;
 
 /**
  * Test {@link SignatureResolver} based on Java source.
@@ -49,9 +49,10 @@ public class SourceSignatureResolverTest extends SignatureResolverTestBase {
 
   @Test
   public void test_innerClassTypeVariable() throws Exception {
-    final IMethod method = type.getType("Inner").getMethods()[0];
-    assertEquals(SignatureResolver.getParameters(method),
-        "Ljava/lang/Comparable;");
+    IType inner = type.getType("Inner");
+    final IMethod method = inner.getMethods()[0];
+    SignatureResolver innerResolver = new SignatureResolver(inner);
+    assertEquals(innerResolver.getParameters(method), "Ljava/lang/Comparable;");
   }
 
 }

--- a/org.eclipse.eclemma.core/src/org/eclipse/eclemma/internal/core/analysis/MethodLocator.java
+++ b/org.eclipse.eclemma.core/src/org/eclipse/eclemma/internal/core/analysis/MethodLocator.java
@@ -44,6 +44,8 @@ public class MethodLocator {
 
   private final IType type;
 
+  private final SignatureResolver resolver;
+
   /**
    * Initializes a new locator for method search within the given type.
    *
@@ -53,6 +55,7 @@ public class MethodLocator {
    */
   public MethodLocator(final IType type) throws JavaModelException {
     this.type = type;
+    this.resolver = new SignatureResolver(type);
     for (final IMethod m : type.getMethods()) {
       addToIndex(m);
     }
@@ -107,7 +110,7 @@ public class MethodLocator {
   private String createParamSignatureKey(final IMethod method)
       throws JavaModelException {
     return method.getElementName() + "#" //$NON-NLS-1$
-        + SignatureResolver.getParameters(method);
+        + resolver.getParameters(method);
   }
 
   private String createParamSignatureKey(final String name,

--- a/org.eclipse.eclemma.doc/pages/changes.html
+++ b/org.eclipse.eclemma.doc/pages/changes.html
@@ -14,6 +14,7 @@
 <h2>Trunk Build (not yet released)</h2>
 
 <ul>
+  <li>Improved analysis performance for large Java files (Eclipse Bug 512756).</li>
   <li>HiDPI icons (Eclipse Bug 507724).</li>
   <li>Import/export session context menu from <i>Coverage</i> view now opens
       corresponding wizard directly. This wasn't the case any more since Eclipse


### PR DESCRIPTION
For large classes with many overloaded method resolving the same types
multiple times can block the UI when drilling the coverage view down to
method level. This fix improves the situation by caching resolved types. 

Bug: 512756