### PR TITLE
Update documentation

### DIFF
--- a/org.eclipse.eclemma.doc/pages/annotations.html
+++ b/org.eclipse.eclemma.doc/pages/annotations.html
@@ -71,9 +71,8 @@
   In some situations it is not obvious, why particular lines do have highlighting
   or have a particular color. The reason is that the underlying code coverage
   library JaCoCo works on Java class files only. In some cases the Java compiler
-  creates extra byte code for a particular line of source code. Such
-  <a class="extern" href="https://github.com/jacoco/jacoco/wiki/FilteringOptions">situations</a>
-  might be filtered by future versions of JaCoCo/EclEmma.
+  creates extra byte code for a particular line of source code. Such situations
+  might be filtered by future versions of JaCoCo and EclEmma.
 </p>
 
 </body>

--- a/org.eclipse.eclemma.doc/pages/changes.html
+++ b/org.eclipse.eclemma.doc/pages/changes.html
@@ -12,7 +12,11 @@
 <h1>EclEmma Change Log</h1>
 
 <h2>Trunk Build (not yet released)</h2>
-
+<p>
+  This is the first release under the umbrella of the Eclipse Foundation.
+  EclEmma is now a official Eclipse.org project and included in several Eclipse
+  Oxygen (4.7) packages.
+</p>
 <ul>
   <li>HiDPI icons (Eclipse Bug 507724).</li>
   <li>Import/export session context menu from <i>Coverage</i> view now opens

--- a/org.eclipse.eclemma.doc/pages/faq.html
+++ b/org.eclipse.eclemma.doc/pages/faq.html
@@ -86,8 +86,7 @@
   means that not all instructions and branches associated with this line have
   been executed during the coverage session. In some cases it is not obvious why
   the Java compiler creates extra byte code for a particular line of source code.
-  Such <a class="extern" href="https://github.com/jacoco/jacoco/wiki/FilteringOptions">situations</a>
-  might be filtered by future versions of JaCoCo/EclEmma.
+  Such situations might be filtered by future versions of JaCoCo and EclEmma.
 </p>
 
 <h3><a name="usage09"></a>How can I exclude test classes from analysis?</h3>
@@ -113,13 +112,13 @@
 <p>
 </p>
 
-<h3><a name="trouble02"></a>Code with exceptions shows no coverage. Why?</h3>
+<h3><a name="trouble02"></a>Source code lines with exceptions show no coverage. Why?</h3>
 <p>
-  The underlying JaCoCo code coverage library works with so called <i>probes</i>.
-  Probes are inserted into the control flow at certain positions. Code is
-  considered as executed when a subsequent probe has been executed. In case of
-  exceptions such a sequence of instructions is aborted somewhere in the middle
-  and not marked as executed.
+  The underlying JaCoCo code coverage library determines code execution with so
+  called probes. Probes are inserted into the control flow at certain positions.
+  Code is considered as executed when a subsequent probe has been executed. In
+  case of exceptions such a sequence of instructions is aborted somewhere in the
+  middle and the corresponding line of source code is not marked as covered.
 </p>
 
 <h3><a name="trouble03"></a>My application does not run with EclEmma!</h3>
@@ -145,8 +144,8 @@
   though they were executed. The reason for this is that underlying JaCoCo code
   coverage library only considers code as executed when certain probes are
   executed. For successful test cases marked with <code>@Test{expected=...}</code>
-  this is not the case. See also <a href="#trouble02">"Code with exceptions
-  shows no coverage. Why?"</a>.
+  this is not the case. See also <a href="#trouble02">"Source code lines with
+  exceptions show no coverage. Why?"</a>.
 </p>
 
 <h3><a name="trouble06">The <i>Coverage</i> view stays empty and there is no source highlighting. Why?</a></h3>

--- a/org.eclipse.eclemma.doc/pages/legal.html
+++ b/org.eclipse.eclemma.doc/pages/legal.html
@@ -11,7 +11,7 @@
 <h1>License</h1>
 
 <p>
-  Copyright &copy; 2006, 2017 Mountainminds GmbH &amp; Co. KG and Contributors
+  Copyright &copy; 2006, 2017 Eclipse Contributors and others
 </p>
 
 <p>
@@ -36,20 +36,6 @@
   The user documentation contains example code taken from the <i>Apache Jakarta
   Commons</i> project, provided under the terms and conditions of the
   <a class="extern" href="http://jakarta.apache.org/commons/license.html">Apache License Version 2.0</a>.
-</p>
-
-<h1>EclEmma.org Content</h1>
-
-<p>
-  Copyright &copy; 2006, 2017 Mountainminds GmbH &amp; Co. KG and Contributors
-</p>
-
-<p>
-  The copyright in <a href="http://www.eclemma.org">www.eclemma.org</a> and the
-  material on this website is owned by Mountainminds GmbH &amp; Co. KG and
-  provided to you under the terms and conditions of the Eclipse Public License
-  Version 1.0 (&quot;EPL&quot;). A copy of the EPL is available at
-  <a class="extern" href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
 </p>
 
 <h1>Trademarks</h1>

--- a/org.eclipse.eclemma.doc/pages/userguide.html
+++ b/org.eclipse.eclemma.doc/pages/userguide.html
@@ -13,17 +13,9 @@
 
 <p>
   EclEmma records which parts of your Java code are executed during a particular
-  program launch. Therefore coverage analysis always involves two steps:
-</p>
-
-<ol>
-  <li>Run the program</li>
-  <li>Analyze coverage data</li>
-</ol>
-
-<p>
-  For reproducible results the launched programs are typically automated tests
-  like JUnit tests.
+  program launch. This technique is called <i>code coverage analysis</i> and
+  typically used with automated testing like JUnit unit tests. It helps to
+  identify untested parts of a code base and improve the corresponding tests.
 </p>
 
 <p>

--- a/org.eclipse.eclemma.doc/toc.xml
+++ b/org.eclipse.eclemma.doc/toc.xml
@@ -16,5 +16,5 @@
   <topic label="Frequently Asked Questions" href="pages/faq.html"/>
   <topic label="Change Log" href="pages/changes.html"/>
   <topic label="Support and Updates" href="pages/support.html"/>
-  <topic label="License" href="pages/license.html"/>
+  <topic label="Legal" href="pages/legal.html"/>
 </toc>


### PR DESCRIPTION
- Adjustments for Eclipse.org
- Update outdated information
- Rename License to Legal for consistency with other Eclipse projects
- Remove copyright for www.eclemma.org