### PR TITLE
use UTF-8 for resources in Oomph setup

### DIFF
--- a/EclEmma.setup
+++ b/EclEmma.setup
@@ -16,6 +16,22 @@
     name="eclemma"
     label="EclEmma">
   <setupTask
+      xsi:type="setup:CompoundTask"
+      name="User Preferences">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/UserPreferences"/>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.core.resources">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.core.resources/encoding"
+          value="UTF-8">
+        <description>Ensure UTF-8 workspace encoding also for Windows (where the default is different)</description>
+      </setupTask>
+    </setupTask>
+  </setupTask>
+  <setupTask
       xsi:type="jdt:JRETask"
       version="JavaSE-1.8"
       location="${jre.location-1.8}">


### PR DESCRIPTION
According to the POMs the sources are all UTF-8, but the Oomph setup
does not set an encoding. On Windows the default encoding is not UTF-8,
therefore this easily leads to confusion in mixed OS environments.

The additional compound task was created by the preference capture
mechanism. I suggest to leave it in, as it is more easy to capture
additional preferences into the setup in the future.

Signed-off-by: Michael Keppler <Michael.Keppler@gmx.de>