### PR TITLE
Use ArrayContentProvider.getInstance() where possible

### DIFF
--- a/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/ScopeViewer.java
+++ b/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/ScopeViewer.java
@@ -148,7 +148,7 @@ public class ScopeViewer implements ISelectionProvider {
   public ScopeViewer(Table table) {
     this.table = table;
     viewer = new CheckboxTableViewer(table);
-    viewer.setContentProvider(new ArrayContentProvider());
+    viewer.setContentProvider(ArrayContentProvider.getInstance());
     viewer.setLabelProvider(new PackageFragmentRootLabelProvider());
     viewer.setSorter(new PackageFragmentRootSorter());
     viewer.addFilter(new ViewerFilter() {

--- a/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/dialogs/CoveragePropertyPage.java
+++ b/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/dialogs/CoveragePropertyPage.java
@@ -154,7 +154,7 @@ public class CoveragePropertyPage extends PropertyPage {
             cell.setText(COUNTER_VALUE.format(line.counter.getTotalCount()));
           }
         });
-    viewer.setContentProvider(new ArrayContentProvider());
+    viewer.setContentProvider(ArrayContentProvider.getInstance());
     viewer.addFilter(new ViewerFilter() {
       @Override
       public boolean select(Viewer viewer, Object parentElement, Object element) {

--- a/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/dialogs/MergeSessionsDialog.java
+++ b/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/dialogs/MergeSessionsDialog.java
@@ -59,7 +59,7 @@ public class MergeSessionsDialog extends ListSelectionDialog {
    */
   public MergeSessionsDialog(Shell parent, List<ICoverageSession> sessions,
       String description) {
-    super(parent, sessions, new ArrayContentProvider(),
+    super(parent, sessions, ArrayContentProvider.getInstance(),
         new WorkbenchLabelProvider(),
         UIMessages.MergeSessionsDialogSelection_label);
     setTitle(UIMessages.MergeSessionsDialog_title);

--- a/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/handlers/DumpExecutionDataHandler.java
+++ b/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/handlers/DumpExecutionDataHandler.java
@@ -105,7 +105,7 @@ public class DumpExecutionDataHandler extends AbstractHandler {
     };
     dialog.setTitle(UIMessages.DumpExecutionDataDialog_title);
     dialog.setMessage(UIMessages.DumpExecutionDataDialog_message);
-    dialog.setContentProvider(new ArrayContentProvider());
+    dialog.setContentProvider(ArrayContentProvider.getInstance());
     dialog.setLabelProvider(new LaunchLabelProvider());
     dialog.setInput(launches);
     if (dialog.open() == Dialog.OK && dialog.getResult().length == 1) {

--- a/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/handlers/SelectActiveSessionHandler.java
+++ b/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/handlers/SelectActiveSessionHandler.java
@@ -53,7 +53,7 @@ public class SelectActiveSessionHandler extends AbstractSessionManagerHandler {
     };
     dialog.setTitle(UIMessages.SelectActiveSessionDialog_title);
     dialog.setMessage(UIMessages.SelectActiveSessionDialog_message);
-    dialog.setContentProvider(new ArrayContentProvider());
+    dialog.setContentProvider(ArrayContentProvider.getInstance());
     dialog.setLabelProvider(new LabelProvider() {
       @Override
       public String getText(Object element) {

--- a/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/wizards/SessionExportPage1.java
+++ b/org.eclipse.eclemma.ui/src/org/eclipse/eclemma/internal/ui/wizards/SessionExportPage1.java
@@ -77,7 +77,7 @@ public class SessionExportPage1 extends WizardPage {
         .setText(UIMessages.ExportSessionPage1Sessions_label);
     sessionstable = new TableViewer(parent, SWT.BORDER);
     sessionstable.setLabelProvider(new WorkbenchLabelProvider());
-    sessionstable.setContentProvider(new ArrayContentProvider());
+    sessionstable.setContentProvider(ArrayContentProvider.getInstance());
     sessionstable.setInput(CoverageTools.getSessionManager().getSessions());
     ICoverageSession active = CoverageTools.getSessionManager()
         .getActiveSession();
@@ -101,7 +101,7 @@ public class SessionExportPage1 extends WizardPage {
     new Label(parent, SWT.NONE)
         .setText(UIMessages.ExportSessionPage1Format_label);
     formatcombo = new ComboViewer(parent, SWT.READ_ONLY);
-    formatcombo.setContentProvider(new ArrayContentProvider());
+    formatcombo.setContentProvider(ArrayContentProvider.getInstance());
     formatcombo.setLabelProvider(new LabelProvider() {
       @Override
       public String getText(Object element) {


### PR DESCRIPTION
As `ArrayContentProvider` is stateless, re-using the global instance avoids a few allocations.

FYI, `ArrayContentProvider.getInstance()` has been around since JFace 3.5 from 2009 ([Bug 249378](https://bugs.eclipse.org/bugs/show_bug.cgi?id=249378)), so I don’t think this presents a compatibility issue.