### PR TITLE
Use icon for "Coverage As" in context and Run menu

### DIFF
--- a/org.eclipse.eclemma.doc/pages/changes.html
+++ b/org.eclipse.eclemma.doc/pages/changes.html
@@ -17,6 +17,8 @@
       generated artifacts, which otherwise require unnecessary and sometimes impossible tricks
       to not have partial or missed coverage, such as for example part of bytecode of try-with
       resources statements (Eclipse Bug 529391, 532770).</li>
+  <li>For consistency with Eclipse Photon UI added icon for "Coverage As" in context and Run
+      menus (Eclipse Bug 530668).</li>
 </ul>
 
 <h2>Version 3.0.1 (2017/11/14)</h2>

--- a/org.eclipse.eclemma.ui/plugin.xml
+++ b/org.eclipse.eclemma.ui/plugin.xml
@@ -204,6 +204,7 @@
                menubarPath="org.eclipse.ui.run/emptyLaunchGroup"/>
          <action
                class="org.eclipse.eclemma.internal.ui.actions.CoverageAsAction"
+               icon="$nl$/icons/full/elcl16/runcoverage.png"
                id="org.eclipse.eclemma.ui.actions.CoverageAsAction"
                label="%CoverageAsAction.label"
                menubarPath="org.eclipse.ui.run/emptyLaunchGroup"
@@ -756,6 +757,7 @@
                class="org.eclipse.eclemma.internal.ui.actions.CoverageContextualLaunchAction"
                menubarPath="additions"
                enablesFor="+"
+               icon="$nl$/icons/full/elcl16/runcoverage.png"
                id="org.eclipse.eclemma.ui.contextualLaunch.coverage.submenu">
          </action>
          <enablement>


### PR DESCRIPTION
This makes EclEmma blend better into Eclipse Photon, where the _Run As_/_Debug As_ menus are now adorned with an icon. See [Bug 530668](https://bugs.eclipse.org/bugs/show_bug.cgi?id=530668) for details.