### PR TITLE
Adjust default colors for Dark theme

### DIFF
--- a/org.eclipse.eclemma.doc/pages/changes.html
+++ b/org.eclipse.eclemma.doc/pages/changes.html
@@ -13,6 +13,10 @@
 
 <h2>Version 3.1.1 (not yet released)</h2>
 
+<ul>
+  <li>Adjusted default colors in Dark theme (Eclipse Bug 533264).</li>
+</ul>
+
 <h2>Version 3.1.0 (2018/06/27)</h2>
 <ul>
   <li>Upgrade to JaCoCo 0.8.1 that provides support for Java 10 and filters out various compiler

--- a/org.eclipse.eclemma.ui/build.properties
+++ b/org.eclipse.eclemma.ui/build.properties
@@ -4,6 +4,7 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                icons/,\
+               css/,\
                plugin.properties,\
                about.html,\
                about.ini,\

--- a/org.eclipse.eclemma.ui/css/dark.css
+++ b/org.eclipse.eclemma.ui/css/dark.css
@@ -1,0 +1,6 @@
+IEclipsePreferences#org-eclipse-ui-editors:org-eclipse-eclemma-ui {
+	preferences:
+		'fullcoverage_color=6,74,6'
+		'partialcoverage_color=98,98,0'
+		'nocoverage_color=98,5,5'
+}

--- a/org.eclipse.eclemma.ui/plugin.xml
+++ b/org.eclipse.eclemma.ui/plugin.xml
@@ -1057,4 +1057,13 @@
          </property>
       </mapping>
    </extension>
+   <extension
+         point="org.eclipse.e4.ui.css.swt.theme">
+      <stylesheet
+            uri="css/dark.css">
+         <themeid
+               refid="org.eclipse.e4.ui.css.theme.e4_dark">
+         </themeid>
+      </stylesheet>
+   </extension>
 </plugin>


### PR DESCRIPTION
Using `Preferences -> General -> Appearance -> Theme: Dark`

On macOS before this change:

![before](https://user-images.githubusercontent.com/138671/42005973-6c67c800-7a77-11e8-9cce-56d221c3c332.png)

After this change:

![after](https://user-images.githubusercontent.com/138671/42005962-65b9f7bc-7a77-11e8-8687-50c2611e818b.png)

On Linux before this change:

![before](https://user-images.githubusercontent.com/138671/42005695-214dde6e-7a76-11e8-950c-f65215622805.png)

After this change:

![after](https://user-images.githubusercontent.com/138671/42005783-a3ba52f6-7a76-11e8-8f90-17f863adf246.png)

Using https://marketplace.eclipse.org/content/darkest-dark-theme

On macOS before and after this change:

![darkest-dark-theme](https://user-images.githubusercontent.com/138671/42005981-74dd5bee-7a77-11e8-9950-7522c0eb8886.png)

On Linux before and after this change:

![darkest-dark-theme](https://user-images.githubusercontent.com/138671/42005906-1dfe2db2-7a77-11e8-831d-70a3cad04d3d.png)
