### PR TITLE
Do not include 3rd party libraries into org.eclipse.eclemma.feature

### DIFF
--- a/org.eclipse.eclemma.feature/feature.xml
+++ b/org.eclipse.eclemma.feature/feature.xml
@@ -51,46 +51,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.jacoco.agent"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.jacoco.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.jacoco.report"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.objectweb.asm"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.objectweb.asm.commons"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.objectweb.asm.tree"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>

--- a/org.eclipse.eclemma.site/category.xml
+++ b/org.eclipse.eclemma.site/category.xml
@@ -8,4 +8,10 @@
          Java code coverage analysis for the Eclipse IDE based on the JaCoCo code coverage library ( http://www.jacoco.org/jacoco )
       </description>
    </category-def>
+   <bundle id="org.jacoco.agent" version="0.0.0"/>
+   <bundle id="org.jacoco.core" version="0.0.0"/>
+   <bundle id="org.jacoco.report" version="0.0.0"/>
+   <bundle id="org.objectweb.asm" version="0.0.0"/>
+   <bundle id="org.objectweb.asm.commons" version="0.0.0"/>
+   <bundle id="org.objectweb.asm.tree" version="0.0.0"/>
 </site>


### PR DESCRIPTION
Instead include them directly in the
org.eclipse.eclemma.site/category.xml

See https://github.com/eclipse-orbit/orbit/discussions/49 :

> ## SimRel Recommendations
> ...
> * It is highly recommended that you stop including (or even importing) 3rd party libraries in your features, particularly in the features that you contribute to the SimRel aggregation.
>   * In order to continue to include such libraries in your update site:
>     * Include them directly in the category.xml.
>     * Define a 3rd party libraries feature, include them there, and include that in your category.xml.
>
> ...