### PR TITLE
Use `skipTests` instead of deprecated `skipExec` parameter of `tycho-surefire-plugin`

### DIFF
--- a/org.eclipse.eclemma.ui.test/pom.xml
+++ b/org.eclipse.eclemma.ui.test/pom.xml
@@ -36,7 +36,7 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>false</useUIThread>
-          <skipExec>${skipUITests}</skipExec>
+          <skipTests>${skipUITests}</skipTests>
           <dependencies>
             <dependency>
               <!-- workaround for missing dependency in org.eclipse.e4.ui.services: https://bugs.eclipse.org/462862 -->


### PR DESCRIPTION
Without this change build produces following warning

```
[INFO] --- tycho-surefire:2.7.5:test (default-test) @ org.eclipse.eclemma.ui.test ---
[WARNING]  Parameter 'skipExec' (user property 'maven.test.skipExec') is deprecated: Use skipTests instead.
```
